### PR TITLE
RowPermissions as MvcModel class Attribute - because web application …

### DIFF
--- a/Plugins/Rhetos.Mvc.Client/HasRowPermissionsAttribute.cs
+++ b/Plugins/Rhetos.Mvc.Client/HasRowPermissionsAttribute.cs
@@ -1,0 +1,29 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System;
+
+namespace Rhetos.Mvc
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class HasRowPermissionsAttribute : Attribute
+    {
+
+    }
+}

--- a/Plugins/Rhetos.Mvc.Client/Rhetos.Mvc.Client.csproj
+++ b/Plugins/Rhetos.Mvc.Client/Rhetos.Mvc.Client.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseMvcModel.cs" />
+    <Compile Include="HasRowPermissionsAttribute.cs" />
     <Compile Include="DeactivatableAttribute.cs" />
     <Compile Include="ExtendsAttribute.cs" />
     <Compile Include="HasHistoryAttribute.cs" />

--- a/Plugins/Rhetos.MvcModelGenerator.DefaultConcepts/DataStructures/RowPermissionReadCodeGenerator.cs
+++ b/Plugins/Rhetos.MvcModelGenerator.DefaultConcepts/DataStructures/RowPermissionReadCodeGenerator.cs
@@ -1,0 +1,42 @@
+﻿/*
+    Copyright (C) 2014 Omega software d.o.o.
+
+    This file is part of Rhetos.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using Rhetos.Compiler;
+using Rhetos.Dsl;
+using Rhetos.Dsl.DefaultConcepts;
+using Rhetos.Extensibility;
+using System.ComponentModel.Composition;
+
+namespace Rhetos.MvcModelGenerator.DefaultConcepts.SimpleBusinessLogic
+{
+    [Export(typeof(IMvcModelGeneratorPlugin))]
+    [ExportMetadata(MefProvider.Implements, typeof(RowPermissionsReadInfo))]
+    public class RowPermissionReadCodeGenerator : IMvcModelGeneratorPlugin
+    {
+
+        public void GenerateCode(IConceptInfo conceptInfo, ICodeBuilder codeBuilder)
+        {
+            var info = (RowPermissionsReadInfo)conceptInfo;
+
+            codeBuilder.InsertCode(
+                "[Rhetos.Mvc.HasRowPermissions]\r\n    ",
+                DataStructureCodeGenerator.AttributesTag, info.Source);
+        }
+    }
+}

--- a/Plugins/Rhetos.MvcModelGenerator.DefaultConcepts/Rhetos.MvcModelGenerator.DefaultConcepts.csproj
+++ b/Plugins/Rhetos.MvcModelGenerator.DefaultConcepts/Rhetos.MvcModelGenerator.DefaultConcepts.csproj
@@ -82,6 +82,7 @@
     <Compile Include="SimpleBusinessLogic\ActiveBoolDefaultCodeGenerator.cs" />
     <Compile Include="SimpleBusinessLogic\HideIdFieldsCodeGenerator.cs" />
     <Compile Include="SimpleBusinessLogic\ReferenceDetailCodeGenerator.cs" />
+    <Compile Include="DataStructures\RowPermissionReadCodeGenerator.cs" />
     <Compile Include="SimpleBusinessLogic\UserRequiredTagCodeGenerator.cs" />
     <Compile Include="SimpleOverridableAttribute.cs" />
     <Compile Include="SimpleBusinessLogic\RegExTagCodeGenerator.cs" />


### PR DESCRIPTION
…has to be aware of defined RowPermissions on DataStructure and query with given Common.RowPermissionReadItems filter.